### PR TITLE
release v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,25 +1,26 @@
 module amuz.es/src/go/misc
 
-go 1.18
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
-	github.com/ericlagergren/decimal v0.0.0-20211103172832-aca2edc11f73
-	github.com/jmoiron/sqlx v1.3.4
+	github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731
+	github.com/jmoiron/sqlx v1.4.0
 	github.com/json-iterator/go v1.1.12
-	github.com/minio/sio v0.3.0
+	github.com/minio/sio v0.4.1
 	github.com/pkg/errors v0.9.1
-	github.com/valyala/fasthttp v1.34.0
-	go.uber.org/multierr v1.8.0
-	golang.org/x/text v0.3.7
+	github.com/valyala/fasthttp v1.59.0
+	go.uber.org/multierr v1.11.0
+	golang.org/x/text v0.22.0
 )
 
 require (
-	github.com/andybalholm/brotli v1.0.4 // indirect
-	github.com/klauspost/compress v1.15.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/crypto v0.35.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )


### PR DESCRIPTION
1. applied fix from See https://go-review.googlesource.com/c/go/+/653675.
2. applied fix from See https://go-review.googlesource.com/c/go/+/653676.
3. go.mod version bumped up to go 1.23.0